### PR TITLE
Python 3.11 versiyon kontrolü kaldırıldı.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12"]
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Artık sadece Python 3.12 versiyon kontrolü yapılıyor.